### PR TITLE
Allow specifying multiple databases and fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:10-alpine
+FROM postgres:10.11-alpine
 MAINTAINER Jonatan Heyman <http://heyman.info>
 
 # Install dependencies

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Required environment variables
 * :code:`AWS_ACCESS_KEY_ID`
 * :code:`AWS_SECRET_ACCESS_KEY`
 * :code:`AWS_DEFAULT_REGION`
+* :code:`DBS`: List of DB connection configs separated with comma in form :code:`<DB_NAME>:<DB_USER>:<DB_PASS>` (e.g.: :code:`db1:user1:pass1,db2:user2:pass2`). If this variable is not empty, DB_NAME, DB_USER, DB_PASS variables are ignored. Backup will be created for each specified database.
 
 Optional environment variables
 ==============================

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+function run_backup() {
+  local database=$(echo $1 | tr ':' ' ' | awk '{print $1}')
+  local user=$(echo $1 | tr ':' ' ' | awk '{print $2}')
+  local pass=$(echo $1 | tr ':' ' ' | awk '{print $3}')
+  echo "backuping ${database}"
+  DB_NAME=$database DB_USER=$user DB_PASS=$pass python -u /backup/backup.py
+}
+
+if [ -n "$DBS" ]; then
+  for db in $(echo $DBS | tr ',' ' '); do
+    run_backup $db
+  done
+else
+  python -u /backup/backup.py
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,6 @@ if [ -z "$CRON_SCHEDULE" ]; then
 fi
 
 # Write cron schedule
-echo "$CRON_SCHEDULE python -u /backup/backup.py > /dev/stdout" >> /var/spool/cron/crontabs/root
+echo "$CRON_SCHEDULE /backup/backup.sh > /dev/stdout" >> /var/spool/cron/crontabs/root
 
 exec "$@"


### PR DESCRIPTION
New env variable supported: $DBS. See README

I've also fixed a base image version to postgres:10.11-alpine because postgres:10-alpine fails to build at the moment due to the back-compatibility issue in apk/python. 