### PR TITLE
Slim the image down somewhat

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -1,15 +1,7 @@
 FROM postgres:10-alpine
 
 # Install dependencies
-RUN apk update && apk add --no-cache --virtual .build-deps && apk add \
-    bash make curl openssh git aws-cli
-
-# Install python
-RUN apk -Uuv add groff less python3
-
-# Cleanup
-RUN rm /var/cache/apk/*
-
+RUN apk add --no-cache -uv curl aws-cli python3
 
 VOLUME ["/data/backups"]
 

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -1,15 +1,7 @@
 FROM postgres:11-alpine
 
 # Install dependencies
-RUN apk update && apk add --no-cache --virtual .build-deps && apk add \
-    bash make curl openssh git aws-cli
-
-# Install python
-RUN apk -Uuv add groff less python3
-
-# Cleanup
-RUN rm /var/cache/apk/*
-
+RUN apk add --no-cache -uv curl aws-cli python3
 
 VOLUME ["/data/backups"]
 

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -1,15 +1,7 @@
 FROM postgres:12-alpine
 
 # Install dependencies
-RUN apk update && apk add --no-cache --virtual .build-deps && apk add \
-    bash make curl openssh git aws-cli
-
-# Install python
-RUN apk -Uuv add groff less python3
-
-# Cleanup
-RUN rm /var/cache/apk/*
-
+RUN apk add --no-cache -uv curl aws-cli python3
 
 VOLUME ["/data/backups"]
 

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -1,15 +1,7 @@
 FROM postgres:13-alpine
 
 # Install dependencies
-RUN apk update && apk add --no-cache --virtual .build-deps && apk add \
-    bash make curl openssh git aws-cli
-
-# Install python
-RUN apk -Uuv add groff less python3
-
-# Cleanup
-RUN rm /var/cache/apk/*
-
+RUN apk add --no-cache -uv curl aws-cli python3
 
 VOLUME ["/data/backups"]
 

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -1,15 +1,7 @@
 FROM postgres:14-alpine
 
 # Install dependencies
-RUN apk update && apk add --no-cache --virtual .build-deps && apk add \
-    bash make curl openssh git aws-cli
-
-# Install python
-RUN apk -Uuv add groff less python3
-
-# Cleanup
-RUN rm /var/cache/apk/*
-
+RUN apk add --no-cache -uv curl aws-cli python3
 
 VOLUME ["/data/backups"]
 

--- a/15/Dockerfile
+++ b/15/Dockerfile
@@ -1,15 +1,7 @@
 FROM postgres:15-alpine
 
 # Install dependencies
-RUN apk update && apk add --no-cache --virtual .build-deps && apk add \
-    bash make curl openssh git aws-cli
-
-# Install python
-RUN apk -Uuv add groff less python3
-
-# Cleanup
-RUN rm /var/cache/apk/*
-
+RUN apk add --no-cache -uv curl aws-cli python3
 
 VOLUME ["/data/backups"]
 

--- a/16/Dockerfile
+++ b/16/Dockerfile
@@ -1,15 +1,7 @@
 FROM postgres:16-alpine
 
 # Install dependencies
-RUN apk update && apk add --no-cache --virtual .build-deps && apk add \
-    bash make curl openssh git aws-cli
-
-# Install python
-RUN apk -Uuv add groff less python3
-
-# Cleanup
-RUN rm /var/cache/apk/*
-
+RUN apk add --no-cache -uv curl aws-cli python3
 
 VOLUME ["/data/backups"]
 

--- a/template/Dockerfile.template
+++ b/template/Dockerfile.template
@@ -1,15 +1,7 @@
 FROM postgres:%(VERSION)s-alpine
 
 # Install dependencies
-RUN apk update && apk add --no-cache --virtual .build-deps && apk add \
-    bash make curl openssh git aws-cli
-
-# Install python
-RUN apk -Uuv add groff less python3
-
-# Cleanup
-RUN rm /var/cache/apk/*
-
+RUN apk add --no-cache -uv curl aws-cli python3
 
 VOLUME ["/data/backups"]
 


### PR DESCRIPTION
Re-order the package installs to save about 100MB.

I also removed several dependencies that didn't seem to be used within the application:

* make
* groff
* git
* openssh

And a couple that are not used directly and are pulled in by postgres or the base alpine:

* bash
* less